### PR TITLE
Add verbose error for attempted http usage.

### DIFF
--- a/src/main/resources/startup.lua
+++ b/src/main/resources/startup.lua
@@ -6,6 +6,7 @@ end
 os.reboot, os.shutdown = do_shutdown, do_shutdown
 
 _G.cct_eval = nil
+_G.http = setmetatable({}, {__index = function() error("HTTP is currently disabled on eval.tweaked.cc", 2) end})
 
 term.clear()
 term.setCursorPos(1, 1)


### PR DESCRIPTION
I see people trying to use the bot to do http stuff on MCCM often, and they often get confused about `attempt to index http (a nil value)`. This will make it so it's more obvious what's going on.